### PR TITLE
Add client-connect-using-class

### DIFF
--- a/class.lisp
+++ b/class.lisp
@@ -47,6 +47,7 @@
            #:clear-methods
            #:dispatch
            #:server-listen
+           #:client-connect-using-class
            #:client-connect
            #:client-disconnect
            #:send-message
@@ -111,13 +112,10 @@
       (start-server transport)))
   server)
 
-(defun client-connect (client &rest initargs &key mode &allow-other-keys)
-  (let* ((class (find-mode-class mode))
-         (initargs (remove-from-plist initargs :mode))
+(defun client-connect-using-class (client class &rest initargs)
+  (let* ((initargs (remove-from-plist initargs :mode))
          (bt:*default-special-bindings* `((*standard-output* . ,*standard-output*)
                                           (*error-output* . ,*error-output*)) ))
-    (unless class
-      (error "Unknown mode ~A" mode))
     (let ((transport (apply #'make-instance class
                             :message-callback
                             (lambda (message)
@@ -131,6 +129,12 @@
 
       (start-client transport)))
   client)
+
+(defun client-connect (client &rest initargs &key mode &allow-other-keys)
+  (let ((class (find-mode-class mode)))
+    (unless class
+      (error "Unknown mode ~A" mode))
+    (apply #'client-connect-using-class client class initargs)))
 
 (defun client-disconnect (client)
   (ensure-connected client)


### PR DESCRIPTION
`jsonrpc/transport/`の下以外でもtransportを定義し、呼び出せるようにするためのインターフェースを追加しました。

これはlem-lsp-modeでasync-processを使った子プロセスとのjsonrpcでの接続をするのに使っています

transportの定義
https://github.com/cxxxr/lem/blob/master/modes/lsp-mode/lem-stdio-transport.lisp

client-connect-using-classの呼出
https://github.com/cxxxr/lem/blob/27c549966e27f886b14afe5152a0999e7f754475/modes/lsp-mode/client.lisp#L46