### PR TITLE
A HTTP transport was added.

### DIFF
--- a/jsonrpc.asd
+++ b/jsonrpc.asd
@@ -8,6 +8,8 @@
   :in-order-to ((test-op (test-op "jsonrpc/tests"))))
 
 (asdf:register-system-packages "clack-handler-hunchentoot" '(#:clack.handler.hunchentoot))
+(asdf:register-system-packages "lack-request" '(#:lack.request))
+(asdf:register-system-packages "http-body" '(#:http-body.util))
 
 (defsystem "jsonrpc/tests"
   :class :package-inferred-system

--- a/main.lisp
+++ b/main.lisp
@@ -67,5 +67,6 @@
 (defun make-client ()
   (make-instance 'client))
 
+
 (defun make-server ()
   (make-instance 'server))

--- a/mapper.lisp
+++ b/mapper.lisp
@@ -2,6 +2,7 @@
 (defpackage #:jsonrpc/mapper
   (:use #:cl
         #:jsonrpc/errors)
+  (:import-from #:dissect)
   (:import-from #:jsonrpc/request-response
                 #:request
                 #:request-method

--- a/request-response.lisp
+++ b/request-response.lisp
@@ -79,7 +79,9 @@
               (hash-table-keys response))))
 
 (defun parse-message (input)
-  (when (< 0 (length input))
+  (when (or (and (typep input 'string)
+                 (< 0 (length input)))
+            (typep input 'stream))
     (let ((message (handler-case (yason:parse input)
                      (error () (error 'jsonrpc-parse-error)))))
       (flet ((make-message (hash)

--- a/transport/http.lisp
+++ b/transport/http.lisp
@@ -1,0 +1,154 @@
+(defpackage #:jsonrpc/transport/http
+  (:use #:cl
+        #:jsonrpc/transport/interface
+        #:jsonrpc/utils)
+  (:import-from #:jsonrpc/errors
+                #:jsonrpc-error)
+  (:import-from #:cl-ppcre)
+  (:import-from #:dexador)
+  (:import-from #:jsonrpc/connection
+                #:connection
+                #:connection-socket
+                #:add-message-to-queue)
+  (:import-from #:jsonrpc/request-response
+                #:response-result
+                #:response-error-code
+                #:response-error-message
+                #:response-error
+                #:make-request
+                #:parse-message)
+  (:import-from #:clack)
+  (:import-from #:clack.handler.hunchentoot)
+  (:import-from #:lack.request)
+  (:import-from #:babel
+                #:octets-to-string)
+  (:import-from #:http-body.util
+                #:detect-charset)
+  (:import-from #:jsonrpc/transport/interface
+                #:run-processing-loop
+                #:send-message-using-transport
+                #:start-client)
+  (:import-from #:jsonrpc/utils
+                #:make-id)
+  (:import-from #:jsonrpc/class
+                #:*default-timeout*
+                #:client)
+  (:export #:make-clack-app
+           #:http-transport))
+(in-package #:jsonrpc/transport/http)
+
+
+(defclass http-transport (transport)
+  ((url :accessor http-transport-url
+        :initarg :url
+        :initform nil)
+   (debug :initarg :debug
+          :initform t)))
+
+
+(defclass http-connection ()
+  ((url :reader connection-url
+        :initarg :url)))
+
+
+(defun make-error-response (code message &key (http-code 500))
+  (let* ((response (list (cons "code" code)
+                         (cons "message" message)))
+         (json (with-output-to-string (s)
+                 (yason:encode-alist response s))))
+    (list http-code
+          (list :content-type "application/json"
+                :allow-origin "*"
+                :access-control-allow-origin "*")
+          (list json))))
+
+
+(defun process-http-request (callback env)
+  (let* ((request (lack.request:make-request env)))
+    (case (lack.request:request-method request)
+      (:options
+       ;; OpenRPC Playground (https://playground.open-rpc.org/) and some other tools
+       ;; may probe for allowed HTTP methods and headers.
+       (list 200
+             (list :access-control-allow-origin "*"
+                   :access-control-allow-methods "POST"
+                   :access-control-allow-headers "Content-Type"
+                   :content-type "plain/text")
+             (list "")))
+      (:post
+       ;; Initially I wanted to hack PARSE-MESSAGE to support stream
+       ;; retrieved by (lack.request:request-raw-body request)
+       ;; but lack returns CIRCULAR-STREAMS:CIRCULAR-INPUT-STREAM
+       ;; which does not support SB-GRAY:STREAM-PEEK-CHAR method.
+       (let* ((raw-content (lack.request:request-content request))
+              (content-type (lack.request:request-content-type request)))
+         (cond
+           ((cl-ppcre:all-matches "^application/json($|;)" content-type)
+            (let* ((content (octets-to-string raw-content
+                                              :encoding (detect-charset content-type :utf-8)))
+                   (message (handler-case (parse-message content)
+                              (jsonrpc-error ()
+                                ;; Nothing can be done
+                                nil))))
+              (cond
+                (message
+                 (let* ((response (funcall callback message))
+                        (json (with-output-to-string (s)
+                                (yason:encode response s)))
+                        (error-code (jsonrpc/request-response:response-error-code response)))
+                   (list (if error-code
+                             ;; This mapping was take from the spec:
+                             ;; https://www.jsonrpc.org/historical/json-rpc-over-http.html#response-codes
+                             (case error-code
+                               (-32600 400)
+                               (-32601 404)
+                               (t 500))
+                             200)
+                         (list :content-type "application/json"
+                               :allow-origin "*"
+                               :access-control-allow-origin "*")
+                         (list json))))
+                (t
+                 (make-error-response -32700 "Unable to parse input message.")))))
+           (t
+            ;; How about using LOG4CL for logging important events?
+            ;; (log:error "Content type ~S is not supported" content-type)
+            (make-error-response -32700 (format nil "Content type \"~A\" is not supported"
+                                                content-type))))))
+      (:get
+       ;; (log:error "GET is not supported")
+       (make-error-response -32700 "GET is not supported")))))
+
+
+(defun make-clack-app (transport)
+  (flet ((json-rpc-http-app (env)
+           (process-http-request (transport-message-callback transport) env)))
+    #'json-rpc-http-app))
+
+
+(defmethod start-client ((transport http-transport))
+  (let ((connection (make-instance 'http-connection
+                                   :url (http-transport-url transport))))
+    (setf (transport-connection transport)
+          connection)))
+
+
+(defmethod jsonrpc:call-to ((from client) (to http-connection) (method string) &optional params &rest options)
+  (destructuring-bind (&key (timeout *default-timeout*)) options
+    (let* ((request (make-request :id (make-id)
+                                  :method method
+                                  :params params))
+           (json (with-output-to-string (s)
+                   (yason:encode request s)))
+           (raw-response (dex:post (connection-url to)
+                                   :content json
+                                   :headers (list (cons :content-type "application/json"))
+                                   :connect-timeout timeout
+                                   :read-timeout timeout))
+           (response (parse-message raw-response)))
+
+      (if (response-error response)
+          (error 'jsonrpc-callback-error
+                 :message (response-error-message response)
+                 :code (response-error-code response))
+          (response-result response)))))

--- a/transport/websocket.lisp
+++ b/transport/websocket.lisp
@@ -22,7 +22,8 @@
   (:import-from #:websocket-driver)
   (:import-from #:clack)
   (:import-from #:clack.handler.hunchentoot)
-  (:export #:websocket-transport))
+  (:export #:websocket-transport
+           #:make-clack-app))
 (in-package #:jsonrpc/transport/websocket)
 
 (defclass websocket-transport (transport)
@@ -50,10 +51,9 @@
       (setf (websocket-transport-port transport) (quri:uri-port uri))))
   transport)
 
-(defmethod start-server ((transport websocket-transport))
-  (setf (transport-connection transport)
-        (clack:clackup
-         (lambda (env)
+
+(defun make-clack-app (transport)
+  (flet ((json-rpc-websocket-app (env)
            (block nil
              ;; Return 200 OK for non-WebSocket requests
              (unless (wsd:websocket-p env)
@@ -91,7 +91,14 @@
                           :name "jsonrpc/transport/websocket processing")))
                    (unwind-protect
                         (wsd:start-connection ws)
-                     (bt:destroy-thread thread)))))))
+                     (bt:destroy-thread thread))))))))
+    #'json-rpc-websocket-app))
+
+
+(defmethod start-server ((transport websocket-transport))
+  (setf (transport-connection transport)
+        (clack:clackup
+         (make-clack-app transport)
          :host (websocket-transport-host transport)
          :port (websocket-transport-port transport)
          :server :hunchentoot


### PR DESCRIPTION
Also, now both Websocket and HTTP transports are export MAKE-CLACK-APP functions. This is useful, when you want to combine api application with some other Clack applications using :mount middleware.

HTTP Transport is useful, when you don't want to keep persistent websocket or TCP connections for each client, because it can be used as a DoS attack on the server.

As a bonus, missing dependency from [dissect](https://quickdocs.org/dissect).