### PR TITLE
fix to leave original bt:*default-special-bindings*

### DIFF
--- a/class.lisp
+++ b/class.lisp
@@ -115,7 +115,8 @@
   (let* ((class (find-mode-class mode))
          (initargs (remove-from-plist initargs :mode))
          (bt:*default-special-bindings* `((*standard-output* . ,*standard-output*)
-                                          (*error-output* . ,*error-output*)) ))
+                                          (*error-output* . ,*error-output*)
+                                          ,@bt:*default-special-bindings*)))
     (unless class
       (error "Unknown mode ~A" mode))
     (let ((transport (apply #'make-instance class
@@ -127,7 +128,8 @@
 (defun client-connect-using-class (client class &rest initargs)
   (let* ((initargs (remove-from-plist initargs :mode))
          (bt:*default-special-bindings* `((*standard-output* . ,*standard-output*)
-                                          (*error-output* . ,*error-output*)) ))
+                                          (*error-output* . ,*error-output*)
+                                          ,@bt:*default-special-bindings*)))
     (let ((transport (apply #'make-instance class
                             :message-callback
                             (lambda (message)


### PR DESCRIPTION
Change original bt:*default-special-bindings* to inherit values to allow binding of yason parsing parameters on the user side.

For example, the yason value will be used when starting the server in the following way
```
(let ((bt:*default-special-bindings*
       `((yason:*parse-json-null-as-keyword* . t)
         (yason:*parse-json-arrays-as-vectors* . t))))
  (jsonrpc:server-listen ...))
```