### PR TITLE
Migrate to bt2 and fix testing

### DIFF
--- a/class.lisp
+++ b/class.lisp
@@ -153,7 +153,7 @@
 (defun client-disconnect (client)
   (ensure-connected client)
   (let ((transport (jsonrpc-transport client)))
-    (mapc #'bt:destroy-thread (transport-threads transport))
+    (mapc #'bt2:destroy-thread (transport-threads transport))
     (setf (transport-threads transport) '())
     (setf (transport-connection transport) nil))
   (emit :close client)

--- a/transport/stdio.lisp
+++ b/transport/stdio.lisp
@@ -32,12 +32,12 @@
                                     :request-callback (transport-message-callback transport))))
     (setf (transport-connection transport) connection)
     (let ((thread
-            (bt:make-thread
+            (bt2:make-thread
              (lambda ()
                (run-processing-loop transport connection))
              :name "jsonrpc/transport/stdio processing")))
       (unwind-protect (run-reading-loop transport connection)
-        (bt:destroy-thread thread)))))
+        (bt2:destroy-thread thread)))))
 
 (defmethod start-client ((transport stdio-transport))
   (let* ((stream (make-two-way-stream (stdio-transport-input transport)
@@ -49,11 +49,11 @@
 
     (setf (transport-threads transport)
           (list
-           (bt:make-thread
+           (bt2:make-thread
             (lambda ()
               (run-processing-loop transport connection))
             :name "jsonrpc/transport/stdio processing")
-           (bt:make-thread
+           (bt2:make-thread
             (lambda ()
               (run-reading-loop transport connection))
             :name "jsonrpc/transport/stdio reading")))

--- a/transport/tcp.lisp
+++ b/transport/tcp.lisp
@@ -59,7 +59,7 @@
                                         :element-type '(unsigned-byte 8))
     (let ((callback (transport-message-callback transport))
           (client-threads '())
-          (bt:*default-special-bindings* (append bt:*default-special-bindings*
+          (bt2:*default-special-bindings* (append bt2:*default-special-bindings*
                                                  `((*standard-output* . ,*standard-output*)
                                                    (*error-output* . ,*error-output*)))))
       (unwind-protect
@@ -73,10 +73,10 @@
                  (setf (transport-connection transport) connection)
                  (emit :open transport connection)
                  (push
-                  (bt:make-thread
+                  (bt2:make-thread
                    (lambda ()
                      (let ((thread
-                             (bt:make-thread
+                             (bt2:make-thread
                               (lambda ()
                                 (run-processing-loop transport connection))
                               :name "jsonrpc/transport/tcp processing"
@@ -87,11 +87,11 @@
                             (run-reading-loop transport connection)
                          (finish-output (connection-socket connection))
                          (usocket:socket-close socket)
-                         (bt:destroy-thread thread)
+                         (bt2:destroy-thread thread)
                          (emit :close connection))))
                    :name "jsonrpc/transport/tcp reading")
                   client-threads))))
-        (mapc #'bt:destroy-thread client-threads)))))
+        (mapc #'bt2:destroy-thread client-threads)))))
 
 (defmethod start-client ((transport tcp-transport))
   (let ((stream (usocket:socket-stream
@@ -108,7 +108,7 @@
                                      :socket stream
                                      :request-callback
                                      (transport-message-callback transport)))
-          (bt:*default-special-bindings* (append bt:*default-special-bindings*
+          (bt2:*default-special-bindings* (append bt2:*default-special-bindings*
                                                  `((*standard-output* . ,*standard-output*)
                                                    (*error-output* . ,*error-output*)))))
       (setf (transport-connection transport) connection)
@@ -117,12 +117,12 @@
 
       (setf (transport-threads transport)
             (list
-             (bt:make-thread
+             (bt2:make-thread
               (lambda ()
                 (run-processing-loop transport connection))
               :name "jsonrpc/transport/tcp processing")
 
-             (bt:make-thread
+             (bt2:make-thread
               (lambda ()
                 (run-reading-loop transport connection))
               :name "jsonrpc/transport/tcp reading")))

--- a/transport/websocket.lisp
+++ b/transport/websocket.lisp
@@ -110,13 +110,14 @@
          :use-thread nil)))
 
 (defmethod start-client ((transport websocket-transport))
-  (let* ((client (wsd:make-client (format nil "~A://~A:~A~A"
-                                          (if (websocket-transport-secure-p transport)
-                                              "wss"
-                                              "ws")
-                                          (websocket-transport-host transport)
-                                          (websocket-transport-port transport)
-                                          (websocket-transport-path transport))))
+  (let* ((client (wsd:make-client (quri:render-uri
+				   (quri:make-uri
+				    :scheme (if (websocket-transport-secure-p transport)
+						"wss"
+						"ws")
+				    :host (websocket-transport-host transport)
+				    :port (websocket-transport-port transport)
+				    :path (websocket-transport-path transport)))))
          (connection (make-instance 'connection
                                     :socket client
                                     :request-callback

--- a/transport/websocket.lisp
+++ b/transport/websocket.lisp
@@ -89,13 +89,13 @@
                (lambda (responder)
                  (declare (ignore responder))
                  (let ((thread
-                         (bt:make-thread
+                         (bt2:make-thread
                           (lambda ()
                             (run-processing-loop transport connection))
                           :name "jsonrpc/transport/websocket processing")))
                    (unwind-protect
                         (wsd:start-connection ws)
-                     (bt:destroy-thread thread))))))))
+                     (bt2:destroy-thread thread))))))))
     #'json-rpc-websocket-app))
 
 
@@ -142,7 +142,7 @@
 
     (setf (transport-threads transport)
           (list
-           (bt:make-thread
+           (bt2:make-thread
             (lambda ()
               (run-processing-loop transport connection))
             :name "jsonrpc/transport/websocket processing")


### PR DESCRIPTION
The changes are:
- update to `bordeaux-threads` 2 API (necessary since dependencies switched already)
- Fix url generation of test suite for websockets. (Now `quri` is used instead of format.)

Usually there should be 2 PRs for each of the issues (since they are not related to each other).
However then the test suite would not work in either, because both stop the tests from succeeding.
So I split it at least in 2 commits.